### PR TITLE
Add 'Show Images Folder' option to the file menu

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,5 +1,7 @@
 import wx
-
+import urllib2
+import os
+from StringIO import StringIO
 class Cache(object):
     def __init__(self):
         self.cache = {}
@@ -7,7 +9,14 @@ class Cache(object):
         if key is None or isinstance(key, wx.Bitmap):
             return key
         if key not in self.cache:
-            self.cache[key] = wx.Bitmap(key)
+            if os.path.exists(key):
+                self.cache[key] = wx.Bitmap(key)
+            else:
+                fp = urllib2.urlopen(key)
+                data = fp.read()
+                fp.close()
+                img = wx.ImageFromStream(StringIO(data))
+                self.cache[key] = img.ConvertToBitmap()
         return self.cache[key]
     def get_color(self, key):
         if key is None or isinstance(key, wx.Colour):


### PR DESCRIPTION
This patch adds a menu item to the 'File' menu that opens the file manager to the folder that stores pyMeme's images.  This makes it easy to curate the collection of images from which the memes are made.

![watch-out-guys-we-got-a-badass-over-here](https://f.cloud.github.com/assets/1383181/1046798/7f984ebe-104a-11e3-86b8-4977b865c258.jpg)
